### PR TITLE
Restrict analytics to reddit.tv. Performance tweaks.

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,15 +22,21 @@
 <script src="js/tv.js" type="text/javascript"></script>
 
 <script type="text/javascript">
-  var _gaq = _gaq || [];
-  _gaq.push(['_setAccount', 'UA-12131688-3']);
-  _gaq.push(['_trackPageview']);
+  if(window.location.host.match('reddit.tv')){
+    consoleLog('Loading analytics ..');
+    var _gaq = _gaq || [];
+    _gaq.push(['_setAccount', 'UA-12131688-3']);
+    _gaq.push(['_trackPageview']);
 
-  (function() {
-    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-  })();
+    (function() {
+      consoleLog('Injecting GA ..');
+      var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+      ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+      var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+    })();
+  }else{
+    consoleLog('Analytics not loaded.');
+  }
 </script>
 </head>
 <body>

--- a/js/tv.js
+++ b/js/tv.js
@@ -146,7 +146,13 @@ $().ready(function(){
     });
 
     /* Anchor Checker */
-    setInterval(checkAnchor, 100);
+    if("onhashchange" in window){
+        window.onhashchange = function(){
+            checkAnchor();
+        }
+    }else{
+        setInterval(checkAnchor, 100);
+    }
 });
 
 /* Main Functions */
@@ -813,5 +819,7 @@ Object.size = function(obj) {
 
 /* analytics */
 function gaHashTrack(){
-    _gaq.push(['_trackPageview',location.pathname + location.hash]);
+    if(_gaq){
+        _gaq.push(['_trackPageview',location.pathname + location.hash]);
+    }
 }

--- a/js/tv.js
+++ b/js/tv.js
@@ -137,6 +137,7 @@ $().ready(function(){
                 window.open($('#vote-button>a').attr('href'), '_blank');
                 break;
             }
+            return false;
         }
     });
 


### PR DESCRIPTION
Match for reddit.tv before loading and injecting GA.

Bind to onhashchange when available instead of using hash lookup loop.

Prevent scroll actions on keyboard shortcuts.
