### PR TITLE
Sort sponsored channels to fourth column.

### DIFF
--- a/js/tv.js
+++ b/js/tv.js
@@ -69,8 +69,12 @@ var RedditTV = Class.extend({
 			$(document).trigger('adsLoaded');
 		});
 
-		if (!self.Globals.channels) self.Globals.channels = [];
-		if (!self.Globals.sponsored_channels) self.Globals.sponsored_channels = [];
+		if (!self.Globals.channels) {
+			self.Globals.channels = [];
+		}
+		if (!self.Globals.sponsored_channels) {
+			self.Globals.sponsored_channels = [];
+		}
 
 		// Load sponsored channel
 		var sponsored_channels = self.Globals.sponsored_channels;
@@ -511,9 +515,11 @@ var RedditTV = Class.extend({
 		var sponsoredChannels = self.Globals.sponsored_channels;
 		var channels = (sorted) ? self.Globals.channel_sorting : self.Globals.channels;
 		
-		if (sorted) channels = $.map(channels, function(feed) {
-			return self.getChanObj(feed);
-		});
+		if (sorted) {
+			channels = $.map(channels, function(feed) {
+				return self.getChanObj(feed);
+			});
+		}
 
 		$.each(sponsoredChannels, function(i, chan) {
 			var n = 2 + i * 4;
@@ -527,7 +533,7 @@ var RedditTV = Class.extend({
 			self.displayChannel(chan);
 		});
 
-    self.bindChannelSorting();
+		self.bindChannelSorting();
 	}, // displayChannels()
 
 	displayChannel: function(chan, added) {

--- a/js/tv.js
+++ b/js/tv.js
@@ -486,9 +486,12 @@ var RedditTV = Class.extend({
 
 	saveChannelOrder: function() {
 		var feeds = [];
-
+		var feed;
 		$('#channels a.channel:not(#add-channel-button):not(.temp)').each(function() {
-			feeds.push($(this).data('feed'));
+			feed = $(this).data('feed');
+			if (!feed.match(/^\/sponsor\//)) {
+				feeds.push(feed);
+			}
 		});
 
 		self.Globals.channel_sorting = feeds;
@@ -521,13 +524,7 @@ var RedditTV = Class.extend({
 			if (!chan.feed) {
 				return;
 			}
-			if (chan.feed.match(/^\/sponsor\//) &&
-					channels.indexOf(chan) == -1) {
-				self.displayChannel(chan, 'sponsor');
-			}
-			else {
-				self.displayChannel(chan);
-			}
+			self.displayChannel(chan);
 		});
 
     self.bindChannelSorting();

--- a/js/tv.js
+++ b/js/tv.js
@@ -70,12 +70,12 @@ var RedditTV = Class.extend({
 		});
 
 		if (!self.Globals.channels) self.Globals.channels = [];
+		if (!self.Globals.sponsored_channels) self.Globals.sponsored_channels = [];
 
 		// Load sponsored channel
 		var sponsored_channels = self.Globals.sponsored_channels;
 		if(sponsored_channels.length >= 1){
 			self.Globals.sponsored_channels = self.formatSponsoredChannels(sponsored_channels);
-			self.Globals.channels = self.Globals.channels.concat(sponsored_channels);
 			for(c in sponsored_channels){
 				self.Globals.videos[sponsored_channels[c].feed] = {
 					video: sponsored_channels[c].videos
@@ -504,27 +504,33 @@ var RedditTV = Class.extend({
 	}, // saveChannelOrder()
 
 	displayChannels: function() {
-		var sorted = (self.Globals.channel_sorting.length),
-			added  = [],
-			lastSponsor;
-
-		$.each(self.Globals.channels, function(i, chan) {
-			if (chan.feed && chan.feed.match(/^\/sponsor\//) && self.Globals.channel_sorting.indexOf(chan.feed) == -1) {
-				self.displayChannel(chan, 'sponsor');
-				added.push(chan.feed);
-			}
-		});
-
+		var sorted = (self.Globals.channel_sorting.length);
+		var sponsoredChannels = self.Globals.sponsored_channels;
 		var channels = (sorted) ? self.Globals.channel_sorting : self.Globals.channels;
+		
+		if (sorted) channels = $.map(channels, function(feed) {
+			return self.getChanObj(feed);
+		});
+
+		$.each(sponsoredChannels, function(i, chan) {
+			var n = 2 + i * 4;
+			channels.splice(n, 0, chan);
+		});
+
 		$.each(channels, function(i, chan) {
-			chan = (sorted) ? self.getChanObj(chan) : chan;
-			if (chan.feed && added.indexOf(chan.feed) == -1) {
+			if (!chan.feed) {
+				return;
+			}
+			if (chan.feed.match(/^\/sponsor\//) &&
+					channels.indexOf(chan) == -1) {
+				self.displayChannel(chan, 'sponsor');
+			}
+			else {
 				self.displayChannel(chan);
-				added.push(chan.feed);
 			}
 		});
 
-    	self.bindChannelSorting();
+    self.bindChannelSorting();
 	}, // displayChannels()
 
 	displayChannel: function(chan, added) {


### PR DESCRIPTION
Currently, any sponsored channels running will get prepended to the list of default channels, causing the sponsored channel to open by default for visitors (which is not what we want!).  This PR instead intersperses any running sponsored channels into every 4th position on the page, so that they'll appear in the right column.

**No sponsored channels**
![screen shot 2014-10-25 at 1 10 32 am](https://cloud.githubusercontent.com/assets/2260961/4787352/b73e582e-5da9-11e4-801d-1a4e2345e9f1.png)

**One sponsored channel**
![screen shot 2014-10-25 at 1 10 52 am](https://cloud.githubusercontent.com/assets/2260961/4787356/be150c9c-5da9-11e4-9407-9e9f2d4f5f4c.png)

**Two sponsored channels\***
![screen shot 2014-10-25 at 1 16 48 am](https://cloud.githubusercontent.com/assets/2260961/4787361/c80825cc-5da9-11e4-92e2-58376b798c3f.png)
_* currently we only allow a single sponsored channel to run at a time on the backend, but the front end puts no restrictions on it_

---

This also prevents sponsored channels from being saved to local storage sorting, so that even if the user moves them, they'll be re-sorted to the right column on page reload.

:eyeglasses: @dwick
