### PR TITLE
Stop storing the 'Add Channel' channel, since it's hardcoded in.

### DIFF
--- a/admin/js/admin.js
+++ b/admin/js/admin.js
@@ -395,13 +395,16 @@ $.each(channelTypes, function(i, channelType) {
 	$('#' + channelType + '-channels').on('submit', function() {
 		var feed = [],
 		    postData;
-
 		$('#' + channelType + '-channels li.channel').each(function() {
-			var chan = $(this),
-			    data = {
-					'channel' : chan.find('.name').text(),
-					'feed'    : chan.attr('data-feed')
-				};
+			var chan = $(this);
+			var data = {
+				'channel' : chan.find('.name').text(),
+				'feed'    : chan.attr('data-feed'),
+			};
+
+			if (typeof data.feed === 'undefined') {
+				return;
+			}
 
 			if (chan.find('.sponsored input').is(':checked')) data.owner = 'sponsor';
 


### PR DESCRIPTION
The 'Add Channel' button is hard-coded into the UI for both the admin interface and the public site, but for some reason updating the default channels in the admin tools causes a 'Add Channel' channel to be created.  This was getting skipped in the rendering on the public site, but certain actions (sorting, commonly) could cause more of these useless objects to get created, and they can't be deleted without manually editing the database.  The admin tool for the live site currently has 3-4 of these taking up space.  This filters out any channels that don't have a `feed` attribute (which should be _every_ channel), which effectively prevents this problem.  

:eyeglasses: @dwick
