### PR TITLE
Fix php notices from missing 'feed' and 'owner' attributes.

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -621,17 +621,27 @@
               <?php
                 $default_channels = json_decode($settings->default_channels);
                 foreach ($default_channels as $channel) :
-                  $thumb_url = '';
-                  $thumb = R::findOne('channel',
-                    ' feed = ? LIMIT 1 ', array( $channel->feed )
-                  );
-                  if ($thumb) $thumb_url = $thumb->thumbnail_url;
+                  $name = isset($channel->channel) ? $channel->channel : null;
+                  if (!$name) {
+                    continue;
+                  }
+                  $feed = isset($channel->feed) ? $channel->feed : '';
+                  $owner = isset($channel->owner) ? $channel->owner : 'site';
+
+                  $thumb = null;
+                  if ($feed) {
+                    $thumb = R::findOne('channel',
+                      ' feed = ? LIMIT 1 ', array( $channel->feed )
+                    );
+                  }
+
+                  $thumb_url = $thumb ? $thumb->thumbnail_url : '';
               ?>
-                  <li class="channel col-lg-3" data-feed="<?php echo $channel->feed; ?>">
+                  <li class="channel col-lg-3" data-feed="<?php echo $feed; ?>">
                     <div class="thumbnail"<?php if ($thumb_url != '') : ?> style="background-image: url(<?php echo $thumb_url; ?>);"<?php endif; ?>>
-                      <div class="sponsored"><label><span>Sponsored</span><input type="checkbox" <?php if ($channel->owner == 'sponsor') : ?>checked="checked"<?php endif; ?>/></label></div>
+                      <div class="sponsored"><label><span>Sponsored</span><input type="checkbox" <?php if ($owner == 'sponsor') : ?>checked="checked"<?php endif; ?>/></label></div>
                     </div>
-                    <span class="name" spellcheck="false" contenteditable="true"><?php echo $channel->channel; ?></span>
+                    <span class="name" spellcheck="false" contenteditable="true"><?php echo $name; ?></span>
                   </li>
               <?php endforeach; ?>
             </ul>
@@ -672,15 +682,24 @@
               <?php
                 $recommended_channels = json_decode($settings->recommended_channels);
                 foreach ($recommended_channels as $channel) :
-                  $thumb_url = '';
-                  $thumb = R::findOne('channel',
-                    ' feed = ? LIMIT 1 ', array( $channel->feed )
-                  );
-                  if ($thumb) $thumb_url = $thumb->thumbnail_url;
+                  $name = isset($channel->channel) ? $channel->channel : null;
+                  if (!$name) {
+                    continue;
+                  }
+                  $feed = isset($channel->feed) ? $channel->feed : '';
+
+                  $thumb = null;
+                  if ($feed) {
+                    $thumb = R::findOne('channel',
+                      ' feed = ? LIMIT 1 ', array( $channel->feed )
+                    );
+                  }
+
+                  $thumb_url = $thumb ? $thumb->thumbnail_url : '';
               ?>
-                  <li class="channel col-lg-3" data-feed="<?php echo $channel->feed; ?>">
+                  <li class="channel col-lg-3" data-feed="<?php echo $feed; ?>">
                     <div class="thumbnail"<?php if ($thumb_url != '') : ?> style="background-image: url(<?php echo $thumb_url; ?>);"<?php endif; ?>></div>
-                    <span class="name" spellcheck="false" contenteditable="true"><?php echo $channel->channel; ?></span>
+                    <span class="name" spellcheck="false" contenteditable="true"><?php echo $name; ?></span>
                   </li>
               <?php endforeach; ?>
             </ul>

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -18,14 +18,18 @@ function getChannels() {
 		$db_table = $type . '_channels';
 		$channels = json_decode($settings->{$db_table});
 		foreach ($channels as $id => $channel) {
-			$thumb = R::findOne('channel',
-			  ' feed = ? LIMIT 1 ', array( $channel->feed )
-			);
+			if (isset($channel->feed)) {
+				$thumb = R::findOne('channel',
+				  ' feed = ? LIMIT 1 ', array( $channel->feed )
+				);
+				if ( $thumb && $thumb->thumbnail_url != '' ) {
+					$channels[$id]->thumbnail = $thumb->thumbnail_url;
+				}
+			}
 
-			if (!$channels[$id]->owner) $channels[$id]->owner = 'site';
-
-			if ( $thumb && $thumb->thumbnail_url != '' )
-				$channels[$id]->thumbnail = $thumb->thumbnail_url;
+			if (!isset($channels[$id]->owner) || !$channels[$id]->owner) {
+				$channels[$id]->owner = 'site';
+			} 
 		}
 
 		$settings_name = $type . '_channels_json';


### PR DESCRIPTION
Default and suggested channels are stored in a json-formatted string in a column of the `settings` table (which has only one row).  Sure.

These get decoded into `stdObject` instances, which are then used in a couple of loops (on both the admin side and the public side) to render the channels.  The problem I ran into is that the objects stored in the json string only have the attributes defined that they have values for, so I was seeing a lot of php notices when accessing `$channel->feed` or `$channel->owner` for channels that didn't have those properties (actually, all channels should have `feed` defined, but that is a separate issue #89).  On production I'm sure these notices don't render, and there isn't any real harm.  Locally, they can cause some problems (like the notice text accidentally getting saved as the value for `feed` or `owner`). Most of all, they should just not be happening.  

:eyeglasses: @Deimos 
