### PR TITLE
Allow multiple sponsored channels and randomize their sort.

### DIFF
--- a/js/tv.js
+++ b/js/tv.js
@@ -1879,6 +1879,7 @@ var RedditTV = Class.extend({
 function shuffleArray(arr) {
 	var i
 	var j;
+	var l;
 	var temp;
 	for (i = 0, l = arr.length; i < l; i++) {
 		j = Math.floor(Math.random() * (i + 1));

--- a/js/tv.js
+++ b/js/tv.js
@@ -1879,7 +1879,7 @@ var RedditTV = Class.extend({
 function shuffleArray(arr) {
 	var i, temp, j;
 	for (var i = 0, l = arr.length; i < l; i++) {
-		j = ~~(Math.random() * (i + 1));
+		j = Math.floor(Math.random() * (i + 1));
 		temp = arr[i];
 		arr[i] = arr[j];
 		arr[j] = temp;

--- a/js/tv.js
+++ b/js/tv.js
@@ -1877,8 +1877,10 @@ var RedditTV = Class.extend({
 
 // http://www.codinghorror.com/blog/2007/12/the-danger-of-naivete.html
 function shuffleArray(arr) {
-	var i, temp, j;
-	for (var i = 0, l = arr.length; i < l; i++) {
+	var i
+	var j;
+	var temp;
+	for (i = 0, l = arr.length; i < l; i++) {
 		j = Math.floor(Math.random() * (i + 1));
 		temp = arr[i];
 		arr[i] = arr[j];

--- a/js/tv.js
+++ b/js/tv.js
@@ -1804,7 +1804,7 @@ var RedditTV = Class.extend({
 				videos: self.formatSponsoredChannelVideos(JSON.parse(channels[c].video_list)),
 			}
 		}
-		return channels;
+		return shuffleArray(channels);
 	}, // formatSponsoredChannels()
 
 	formatSponsoredChannelVideos: function(videos) {
@@ -1874,6 +1874,18 @@ var RedditTV = Class.extend({
         return (navigator.userAgent.match(/iPad/i) != null);
     }, // isiPad
 });
+
+// http://www.codinghorror.com/blog/2007/12/the-danger-of-naivete.html
+function shuffleArray(arr) {
+	var i, temp, j;
+	for (var i = 0, l = arr.length; i < l; i++) {
+		j = ~~(Math.random() * (i + 1));
+		temp = arr[i];
+		arr[i] = arr[j];
+		arr[j] = temp;
+	}
+	return arr;
+}
 
 var rtv;
 $(document).ready(function() {

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -41,7 +41,6 @@ function getSponsoredChannels() {
 		AND start_date <= NOW()
 		AND end_date >= NOW()
 		ORDER BY start_date DESC
-		LIMIT 1
 	  '
 	);
 


### PR DESCRIPTION
Removes limit on number of sponsored channels that can run at the same time, and also randomizes their sort.  Initially tried to do the randomization on the backend, but caching was an issue.

:eyeglasses: @Deimos
